### PR TITLE
Adding a simple version for updating entities

### DIFF
--- a/client/src/main/java/uk/co/blackpepper/bowman/Client.java
+++ b/client/src/main/java/uk/co/blackpepper/bowman/Client.java
@@ -25,6 +25,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import uk.co.blackpepper.bowman.annotation.RemoteResource;
 
+import static uk.co.blackpepper.bowman.ReflectionSupport.getId;
 import static uk.co.blackpepper.bowman.ReflectionSupport.setId;
 
 /**
@@ -117,6 +118,16 @@ public class Client<T> {
 		setId(object, resourceUri);
 		
 		return resourceUri;
+	}
+	
+	/**
+	 * PUT the given entity to the entity's collection resource.
+	 *
+	 * @param object the entity to submit
+	 * @return the URI ID of the newly created remote entity
+	 */
+	public void put(T object) {
+		restOperations.putObject(getId(object), object);
 	}
 
 	/**

--- a/client/src/main/java/uk/co/blackpepper/bowman/RestOperations.java
+++ b/client/src/main/java/uk/co/blackpepper/bowman/RestOperations.java
@@ -82,6 +82,10 @@ class RestOperations {
 		return restTemplate.postForLocation(uri, object);
 	}
 	
+	public void putObject(URI uri, Object object) {
+		restTemplate.put(uri, object);
+	}
+	
 	public void deleteResource(URI uri) {
 		restTemplate.delete(uri);
 	}

--- a/client/src/test/java/uk/co/blackpepper/bowman/RestOperationsTest.java
+++ b/client/src/test/java/uk/co/blackpepper/bowman/RestOperationsTest.java
@@ -151,6 +151,14 @@ public class RestOperationsTest {
 	}
 	
 	@Test
+	public void putObjectPutsObject() {
+		Entity entity = new Entity();
+		restOperations.putObject(URI.create("http://example.com/1"), entity);
+		
+		verify(restTemplate).put(URI.create("http://example.com/1"), entity);
+	}
+	
+	@Test
 	public void deleteResourceDeletesResource() {
 		restOperations.deleteResource(URI.create("http://example.com/1"));
 		

--- a/test/it/src/test/java/uk/co/blackpepper/bowman/test/it/BidiIT.java
+++ b/test/it/src/test/java/uk/co/blackpepper/bowman/test/it/BidiIT.java
@@ -55,7 +55,7 @@ public class BidiIT extends AbstractIT {
 	}
 	
 	@Test
-	public void canGetChildrenAssocation() {
+	public void canGetChildrenAssociation() {
 		BidiParentEntity parent = new BidiParentEntity();
 		URI location = parentClient.post(parent);
 		

--- a/test/it/src/test/java/uk/co/blackpepper/bowman/test/it/InlineBidiIT.java
+++ b/test/it/src/test/java/uk/co/blackpepper/bowman/test/it/InlineBidiIT.java
@@ -41,7 +41,7 @@ public class InlineBidiIT extends AbstractIT {
 	}
 	
 	@Test
-	public void canGetChildAssocation() {
+	public void canGetChildAssociation() {
 		SimpleEntity related = new SimpleEntity();
 		related.setName("related");
 		simpleEntityClient.post(related);
@@ -51,7 +51,6 @@ public class InlineBidiIT extends AbstractIT {
 		InlineBidiChildEntity child = new InlineBidiChildEntity();
 		child.setName("x");
 		child.setRelated(related);
-//		child.setParent(parent);
 
 		parent.setChild(child);
 		
@@ -65,7 +64,7 @@ public class InlineBidiIT extends AbstractIT {
 	}
 	
 	@Test
-	public void canGetChildrenAssocation() {
+	public void canGetChildrenAssociation() {
 		SimpleEntity related = new SimpleEntity();
 		related.setName("related");
 		simpleEntityClient.post(related);
@@ -75,7 +74,6 @@ public class InlineBidiIT extends AbstractIT {
 		InlineBidiChildEntity child = new InlineBidiChildEntity();
 		child.setName("x");
 		child.setRelated(related);
-//		child.setParent(parent);
 
 		parent.getChildren().add(child);
 		

--- a/test/it/src/test/java/uk/co/blackpepper/bowman/test/it/SimpleEntityIT.java
+++ b/test/it/src/test/java/uk/co/blackpepper/bowman/test/it/SimpleEntityIT.java
@@ -80,4 +80,23 @@ public class SimpleEntityIT extends AbstractIT {
 		
 		client.post(sent);
 	}
+	
+	@Test
+	public void canPutEntity() {
+		SimpleEntity sent = new SimpleEntity();
+		sent.setName("current");
+		
+		URI posted = client.post(sent);
+		
+		assertThat(sent.getId(), is(posted));
+		assertThat(sent.getName(), is("current"));
+		
+		sent.setName("updated");
+		client.put(sent);
+		
+		SimpleEntity updated = client.get(sent.getId());
+		
+		assertThat(updated.getId(), is(posted));
+		assertThat(updated.getName(), is("updated"));
+	}
 }


### PR DESCRIPTION
This PR will add the basic functionality to update an entity. In case you use Spring Data Rest as a backend the associations will not be touch. These associations needs to be updated in separate call to the API.