### PR TITLE
Support 'is' prefix in proxy class to have boolean getters

### DIFF
--- a/client/src/main/java/uk/co/blackpepper/bowman/JavassistClientProxyFactory.java
+++ b/client/src/main/java/uk/co/blackpepper/bowman/JavassistClientProxyFactory.java
@@ -29,7 +29,7 @@ class JavassistClientProxyFactory implements ClientProxyFactory {
 	private static final class GetterMethodFilter implements MethodFilter {
 		@Override
 		public boolean isHandled(Method method) {
-			return method.getName().startsWith("get");
+			return method.getName().startsWith("get") || method.getName().startsWith("is");
 		}
 	}
 	

--- a/client/src/test/java/uk/co/blackpepper/bowman/JavassistClientProxyFactoryTest.java
+++ b/client/src/test/java/uk/co/blackpepper/bowman/JavassistClientProxyFactoryTest.java
@@ -45,6 +45,8 @@ public class JavassistClientProxyFactoryTest {
 		
 		private Entity linked;
 		
+		private boolean active;
+		
 		private List<Entity> linkedCollection = new ArrayList<>();
 		
 		@ResourceId
@@ -65,6 +67,14 @@ public class JavassistClientProxyFactoryTest {
 		@LinkedResource
 		public List<Entity> getLinkedCollection() {
 			return linkedCollection;
+		}
+		
+		public boolean isActive() {
+			return active;
+		}
+		
+		public void setActive(boolean active) {
+			this.active = active;
 		}
 	}
 	
@@ -130,5 +140,20 @@ public class JavassistClientProxyFactoryTest {
 		Entity proxy = proxyFactory.create(resource, Entity.class, restOperations);
 		
 		assertThat(proxy.getLinkedCollection().get(0).getId(), is(URI.create("http://www.example.com/1")));
+	}
+	
+	@Test
+	public void createReturnsProxyWithActive() {
+		Entity entity = new Entity();
+		entity.setActive(true);
+		
+		Resource<Entity> resource = new Resource<>(entity,
+			new Link("http://www.example.com/1", Link.REL_SELF));
+		
+		Entity proxy = proxyFactory.create(resource,
+			Entity.class, mock(RestOperations.class));
+		
+		assertThat(proxy.getId(), is(URI.create("http://www.example.com/1")));
+		assertThat(proxy.isActive(), is(true));
 	}
 }


### PR DESCRIPTION
In case your entities using booleans and you prefer to use the 'is' prefix instead of the 'get' the generated proxy will ignore it. The PR modifies the proxy method filter and enables 'is' prefixes.