### PR TITLE
Updating the proxy via set will update the resource too

### DIFF
--- a/client/src/main/java/uk/co/blackpepper/bowman/GetterSetterMethodHandler.java
+++ b/client/src/main/java/uk/co/blackpepper/bowman/GetterSetterMethodHandler.java
@@ -27,13 +27,16 @@ import org.springframework.hateoas.Link;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+
 import javassist.util.proxy.MethodHandler;
 import uk.co.blackpepper.bowman.annotation.LinkedResource;
 import uk.co.blackpepper.bowman.annotation.ResourceId;
 
 import static uk.co.blackpepper.bowman.HalSupport.toLinkName;
 
-class GetterMethodHandler<T> implements MethodHandler {
+@JsonIgnoreType
+class GetterSetterMethodHandler<T> implements MethodHandler {
 	
 	private final URI uri;
 	
@@ -47,12 +50,12 @@ class GetterMethodHandler<T> implements MethodHandler {
 	
 	private final Map<String, Object> linkedResourceResults = new HashMap<>();
 	
-	GetterMethodHandler(Resource<T> resource, Class<T> entityType, RestOperations restOperations,
+	GetterSetterMethodHandler(Resource<T> resource, Class<T> entityType, RestOperations restOperations,
 		ClientProxyFactory proxyFactory) {
 		this(getResourceURI(resource), resource, entityType, restOperations, proxyFactory);
 	}
 
-	private GetterMethodHandler(URI uri, Resource<T> resource, Class<T> entityType, RestOperations restOperations,
+	private GetterSetterMethodHandler(URI uri, Resource<T> resource, Class<T> entityType, RestOperations restOperations,
 		ClientProxyFactory proxyFactory) {
 		this.uri = uri;
 		this.resource = resource;
@@ -67,6 +70,10 @@ class GetterMethodHandler<T> implements MethodHandler {
 	public Object invoke(Object self, Method method, Method proceed, Object[] args) throws Throwable {
 		
 		// CHECKSTYLE:ON
+		
+		if (method.getName().startsWith("set")) {
+			return method.invoke(resource.getContent(), args);
+		}
 		
 		if (method.isAnnotationPresent(ResourceId.class)) {
 			return uri;

--- a/client/src/main/java/uk/co/blackpepper/bowman/JavassistClientProxyFactory.java
+++ b/client/src/main/java/uk/co/blackpepper/bowman/JavassistClientProxyFactory.java
@@ -26,18 +26,20 @@ import javassist.util.proxy.ProxyFactory;
 
 class JavassistClientProxyFactory implements ClientProxyFactory {
 
-	private static final class GetterMethodFilter implements MethodFilter {
+	private static final class GetterSetterMethodFilter implements MethodFilter {
 		@Override
 		public boolean isHandled(Method method) {
-			return method.getName().startsWith("get") || method.getName().startsWith("is");
+			return method.getName().startsWith("get")
+				|| method.getName().startsWith("is") || method.getName().startsWith("set");
 		}
 	}
 	
-	private static final MethodFilter FILTER_INSTANCE = new GetterMethodFilter();
+	private static final MethodFilter FILTER_INSTANCE = new GetterSetterMethodFilter();
 
 	@Override
 	public <T> T create(Resource<T> resource, Class<T> entityType, RestOperations restOperations) {
-		return createProxyInstance(entityType, new GetterMethodHandler<>(resource, entityType, restOperations, this));
+		return createProxyInstance(entityType,
+			new GetterSetterMethodHandler<>(resource, entityType, restOperations, this));
 	}
 
 	private static <T> T createProxyInstance(Class<T> entityType, MethodHandler methodHandler) {

--- a/client/src/test/java/uk/co/blackpepper/bowman/JavassistClientProxyFactoryTest.java
+++ b/client/src/test/java/uk/co/blackpepper/bowman/JavassistClientProxyFactoryTest.java
@@ -156,4 +156,20 @@ public class JavassistClientProxyFactoryTest {
 		assertThat(proxy.getId(), is(URI.create("http://www.example.com/1")));
 		assertThat(proxy.isActive(), is(true));
 	}
+	
+	@Test
+	public void createReturnsProxyWithSettingValuesPossible() {
+		Entity entity = new Entity();
+		entity.setActive(true);
+		
+		Resource<Entity> resource = new Resource<>(entity,
+			new Link("http://www.example.com/1", Link.REL_SELF));
+		
+		Entity proxy = proxyFactory.create(resource,
+			Entity.class, mock(RestOperations.class));
+		
+		proxy.setActive(false);
+		
+		assertThat(proxy.isActive(), is(false));
+	}
 }

--- a/test/it/src/test/java/uk/co/blackpepper/bowman/test/it/SimpleEntityIT.java
+++ b/test/it/src/test/java/uk/co/blackpepper/bowman/test/it/SimpleEntityIT.java
@@ -114,4 +114,25 @@ public class SimpleEntityIT extends AbstractIT {
 		assertThat(updated.getId(), is(posted));
 		assertThat(updated.getName(), is("updated"));
 	}
+	
+	@Test
+	public void canGetAndPutEntity() {
+		SimpleEntity sent = new SimpleEntity();
+		sent.setName("current");
+		
+		URI posted = client.post(sent);
+		
+		assertThat(sent.getId(), is(posted));
+		assertThat(sent.getName(), is("current"));
+		
+		sent = client.get(posted);
+		
+		sent.setName("updated");
+		client.put(sent);
+		
+		SimpleEntity updated = client.get(sent.getId());
+		
+		assertThat(updated.getId(), is(posted));
+		assertThat(updated.getName(), is("updated"));
+	}
 }


### PR DESCRIPTION
Hello,

this PR will fix two problems.

1. The poxy handler will not be serialised by jackson. This happens if you want to put or post an already fetched, proxied, entity.
2. If you modify a proxied, fetched, entity it will persist the change in the wrapped entity from the resource. 

I hope I covered all the cases in the tests.