### PR TITLE
Open up the object mapper configuration

### DIFF
--- a/client/src/main/java/uk/co/blackpepper/bowman/Configuration.java
+++ b/client/src/main/java/uk/co/blackpepper/bowman/Configuration.java
@@ -39,6 +39,8 @@ public final class Configuration {
 		private URI baseUri = URI.create("http://localhost:8080");
 		
 		private RestTemplateConfigurer restTemplateConfigurer;
+		
+		private ObjectMapperConfigurer objectMapperConfigurer;
 
 		private ClientHttpRequestFactory clientHttpRequestFactory = new HttpComponentsClientHttpRequestFactory();
 		
@@ -108,6 +110,18 @@ public final class Configuration {
 			this.clientHttpRequestFactory = clientHttpRequestFactory;
 			return this;
 		}
+		
+		/**
+		 * Set the <code>ObjectMapperConfigurer</code> for the created configuration. Allows
+		 * further configuration of the Jackson <code>ObjectMapper</code> used internally.
+		 *
+		 * @param objectMapperConfigurer the <code>ObjectMapperConfigurer</code>
+		 * @return this builder
+		 */
+		public Builder setObjectMapperConfigurer(ObjectMapperConfigurer objectMapperConfigurer) {
+			this.objectMapperConfigurer = objectMapperConfigurer;
+			return this;
+		}
 	}
 	
 	private final URI baseUri;
@@ -116,10 +130,13 @@ public final class Configuration {
 	
 	private final ClientHttpRequestFactory clientHttpRequestFactory;
 	
+	private final ObjectMapperConfigurer objectMapperConfigurer;
+	
 	private Configuration(Builder builder) {
 		baseUri = builder.baseUri;
 		restTemplateConfigurer = builder.restTemplateConfigurer;
 		clientHttpRequestFactory = builder.clientHttpRequestFactory;
+		objectMapperConfigurer = builder.objectMapperConfigurer;
 	}
 	
 	/**
@@ -174,5 +191,14 @@ public final class Configuration {
 	 */
 	public ClientHttpRequestFactory getClientHttpRequestFactory() {
 		return clientHttpRequestFactory;
+	}
+	
+	/**
+	 * Get the <code>ObjectMapperConfigurer</code> for this configuration.
+	 *
+	 * @return the configuration's <code>ObjectMapperConfigurer</code>.
+	 */
+	public ObjectMapperConfigurer getObjectMapperConfigurer() {
+		return objectMapperConfigurer;
 	}
 }

--- a/client/src/main/java/uk/co/blackpepper/bowman/ObjectMapperConfigurer.java
+++ b/client/src/main/java/uk/co/blackpepper/bowman/ObjectMapperConfigurer.java
@@ -1,0 +1,14 @@
+package uk.co.blackpepper.bowman;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Interface supporting the configuration of the Jackson {@link com.fasterxml.jackson.databind.ObjectMapper} which is
+ * used internally by the {@link Client}.
+ *
+ * @author Karl Spies
+ */
+public interface ObjectMapperConfigurer {
+	
+	void configure(ObjectMapper objectMapper);
+}

--- a/client/src/main/java/uk/co/blackpepper/bowman/RestOperationsFactory.java
+++ b/client/src/main/java/uk/co/blackpepper/bowman/RestOperationsFactory.java
@@ -52,6 +52,10 @@ class RestOperationsFactory {
 				configuration.getRestTemplateConfigurer().configure(restTemplate);
 			}
 			
+			if (configuration.getObjectMapperConfigurer() != null) {
+				configuration.getObjectMapperConfigurer().configure(objectMapper);
+			}
+			
 			restOperations = new RestOperations(restTemplate, objectMapper);
 			
 			handlerMap.put(InlineAssociationDeserializer.class,

--- a/client/src/test/java/uk/co/blackpepper/bowman/RestOperationsFactoryTest.java
+++ b/client/src/test/java/uk/co/blackpepper/bowman/RestOperationsFactoryTest.java
@@ -111,6 +111,23 @@ public class RestOperationsFactoryTest {
 		
 		verify(restTemplateConfigurer).configure(restTemplate);
 	}
+	
+	@Test
+	public void createInvokesConfigurerOnObjectMapperIfPresent() {
+		ObjectMapperConfigurer objectMapperConfigurer = mock(ObjectMapperConfigurer.class);
+		Configuration configuration = Configuration.builder()
+			.setObjectMapperConfigurer(objectMapperConfigurer)
+			.build();
+		
+		ObjectMapper objectMapper = new ObjectMapper();
+		when(mapperFactory.create(any(HandlerInstantiator.class)))
+			.thenReturn(objectMapper);
+		
+		new RestOperationsFactory(configuration, proxyFactory, mapperFactory, restTemplateFactory)
+			.create();
+		
+		verify(objectMapperConfigurer).configure(objectMapper);
+	}
 
 	private static Matcher<RestOperations> aRestOperationsMatching(final RestTemplate restTemplate,
 			final ObjectMapper mapper) {


### PR DESCRIPTION
This PR will add a new feature to configure the internal Jackson `ObjectMapper`. For example you would like to use Java 8 time datatypes you can use the following code:

```java
Configuration.builder()
	.setBaseUri(System.getProperty("baseUrl"))
	.setClientHttpRequestFactory(new BufferingClientHttpRequestFactory(
	    new HttpComponentsClientHttpRequestFactory()))
	.setObjectMapperConfigurer(new ObjectMapperConfigurer() {
		@Override
		public void configure(ObjectMapper objectMapper) {
			objectMapper.registerModule(new JavaTimeModule());
		}
	})
	.build();
```