### PR TITLE
move spring-test dependency to maven test scope

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -79,6 +79,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
currently the bowman artifact is transitively including spring-test.  this should fix that.