### PR TITLE
Don't send extraneous 'handler' property on proxy

### DIFF
--- a/client/src/main/java/uk/co/blackpepper/bowman/JacksonClientModule.java
+++ b/client/src/main/java/uk/co/blackpepper/bowman/JacksonClientModule.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.springframework.hateoas.Resource;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.BeanDescription;
@@ -31,6 +32,7 @@ import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
+import javassist.util.proxy.MethodHandler;
 import uk.co.blackpepper.bowman.annotation.LinkedResource;
 
 /**
@@ -39,7 +41,8 @@ import uk.co.blackpepper.bowman.annotation.LinkedResource;
  * <p>Registering this module with an {@link com.fasterxml.jackson.databind.ObjectMapper}
  * will cause properties annotated with {@link LinkedResource} to be serialized as
  * URI strings (single-valued associations) or arrays of URI strings (collection-valued
- * associations).
+ * associations), and properties of type {@link javassist.util.proxy.MethodHandler} to
+ * not be serialized.
  * 
  * @author Ryan Pickett
  * 
@@ -56,6 +59,9 @@ public class JacksonClientModule extends SimpleModule {
 		}
 	}
 	
+	@JsonIgnoreType
+	abstract static class MethodHandlerMixin { }
+
 	private static class LinkedResourceUriSerializer extends StdSerializer<Object> {
 
 		private static final long serialVersionUID = -5901774722661025524L;
@@ -102,5 +108,6 @@ public class JacksonClientModule extends SimpleModule {
 		});
 		
 		setMixInAnnotation(Resource.class, ResourceMixin.class);
+		setMixInAnnotation(MethodHandler.class, MethodHandlerMixin.class);
 	}
 }

--- a/client/src/test/java/uk/co/blackpepper/bowman/JacksonClientModuleTest.java
+++ b/client/src/test/java/uk/co/blackpepper/bowman/JacksonClientModuleTest.java
@@ -25,11 +25,13 @@ import org.junit.Test;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import javassist.util.proxy.MethodHandler;
 import uk.co.blackpepper.bowman.annotation.LinkedResource;
 import uk.co.blackpepper.bowman.annotation.RemoteResource;
 import uk.co.blackpepper.bowman.annotation.ResourceId;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 
 public class JacksonClientModuleTest {
@@ -112,5 +114,17 @@ public class JacksonClientModuleTest {
 		String json = mapper.writeValueAsString(new Entity("x"));
 		
 		assertThat(json, containsString("\"simple\":\"x\""));
+	}
+
+	@Test
+	public void handlerOnJavassistProxyIsNotSerialized() throws Exception {
+		Entity proxy = new Entity("x") {
+			public MethodHandler getHandler() {
+				return null;
+			}
+		};
+		String json = mapper.writeValueAsString(proxy);
+
+		assertThat(json, not(containsString("\"handler\"")));
 	}
 }


### PR DESCRIPTION
Ignore properties of type javassist.util.proxy.MethodHandler present on the proxies generated by JavAssist.