### PR TITLE
Remove unused annotation from MethodHandlerChain

### DIFF
--- a/client/src/main/java/uk/co/blackpepper/bowman/MethodHandlerChain.java
+++ b/client/src/main/java/uk/co/blackpepper/bowman/MethodHandlerChain.java
@@ -4,12 +4,9 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreType;
-
 import javassist.util.proxy.MethodFilter;
 import javassist.util.proxy.MethodHandler;
 
-@JsonIgnoreType
 class MethodHandlerChain implements MethodHandler, MethodFilter {
 	
 	private List<ConditionalMethodHandler> delegateHandlers;


### PR DESCRIPTION
A tidy up spotted when developing the fix for issue #24, but forgot at the time.